### PR TITLE
GH-17 GH-19: implement catalog access

### DIFF
--- a/_modules/consul_mod.py
+++ b/_modules/consul_mod.py
@@ -2,6 +2,11 @@
 '''
 Execution module to provide consul functionality to Salt
 
+:maintainer: Aaron Bell <aarontbellgmail.com>
+:maturity: new
+:depends:    - python-consul (http://python-consul.readthedocs.org/en/latest/)
+:platform: Linux
+
 .. versionadded:: 2014.7.0
 
 :configuration: This module requires the python-consul python module and uses the

--- a/_modules/consul_mod.py
+++ b/_modules/consul_mod.py
@@ -149,10 +149,10 @@ def service_get(name, dc=None, tag=None, index=None):
         salt '*' consul.service_get
     '''
     c = _connect()
-    index, service = c.agent.service(name, dc, tag, index)
-    if not service:
-        return False
-    return service
+    for service, data in c.agent.services().items():
+        if name == service:
+            return data
+    return False
 
 
 def service_register(name, service_id=None, port=None, tags=None, script=None, interval=None, ttl=None):

--- a/_modules/consul_mod.py
+++ b/_modules/consul_mod.py
@@ -24,6 +24,7 @@ except ImportError:
 
 __virtualname__ = 'consul'
 
+
 def __virtual__():
     '''
     Only load this module if python-consul
@@ -120,24 +121,24 @@ def key_put(key, value):
     return data['Value']
 
 
-def service_list():
+def service_list(catalog=False, dc=None, index=None):
     '''
     List services known to Consul
-
     CLI Example:
-
     .. code-block:: bash
-
         salt '*' consul.service_list
     '''
     c = _connect()
     services = []
-    for service, data in c.agent.services().items():
-        services.append(service)
+    if catalog:
+        index, services = c.catalog.services(dc, index)
+    else:
+        for service, data in c.agent.services().items():
+            services.append(service)
     return services
 
 
-def service_get(name):
+def service_get(name, dc=None, tag=None, index=None):
     '''
     Get a Consul service's details
 
@@ -148,10 +149,10 @@ def service_get(name):
         salt '*' consul.service_get
     '''
     c = _connect()
-    for service, data in c.agent.services().items():
-        if name == service:
-            return data
-    return False
+    index, service = c.agent.service(name, dc, tag, index)
+    if not service:
+        return False
+    return service
 
 
 def service_register(name, service_id=None, port=None, tags=None, script=None, interval=None, ttl=None):
@@ -266,3 +267,107 @@ def get_service_status(name,index=None, passing=None):
             if name == check['ServiceName']:
                 node_list.append({check['Node']: check['Status']})
     return node_list
+
+
+def node_list():
+    '''
+    List nodes in Consul
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' consul.node_list
+    '''
+    c = _connect()
+    node_list = []
+    index, nodes = c.catalog.nodes()
+    for node in nodes:    
+        node_list.append({node['Node']: node['Address']})
+    return node_list
+
+
+def node_get(name, dc=None, tag=None, index=None):
+    '''
+    Get a Consul node's details
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' consul.node_get
+    '''
+    c = _connect()
+    index, node = c.catalog.node(name, dc, tag, index)
+    if not node:
+        return False
+    return node
+
+
+def dc_list():
+    '''
+    List datacenters in Consul
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' consul.dc_list
+    '''
+    c = _connect()
+    return c.catalog.datacenters()
+
+
+def ttl_pass(name, notes=None, type='check'):
+    '''
+    Mark a ttl-based service or check as passing
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' consul.ttl_pass foo type=check
+        
+        salt '*' consul.ttl_pass foo type=service
+    '''
+    c = _connect()
+    if type == 'service':
+        name = 'service:' + name
+    return c.agent.check.ttl_pass(name, notes)
+
+
+def ttl_warn(name, notes=None, type='check'):
+    '''
+    Mark a ttl-based service or check as warning
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' consul.ttl_warn foo type=check
+        
+        salt '*' consul.ttl_warn foo type=service
+    '''
+    c = _connect()
+    if type == 'service':
+        name = 'service:' + name
+    return c.agent.check.ttl_warn(name, notes)
+
+
+def ttl_fail(name, notes=None, type='check'):
+    '''
+    Mark a ttl-based service or check as failing
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' consul.ttl_fail foo type=check
+        
+        salt '*' consul.ttl_fail foo type=service
+    '''
+    c = _connect()
+    if type == 'service':
+        name = 'service:' + name
+    return c.agent.check.ttl_fail(name, notes)
+

--- a/_states/consul_check.py
+++ b/_states/consul_check.py
@@ -90,4 +90,41 @@ def absent(name):
         __salt__['consul.check_deregister'](name)
     
     return ret
+
+
+def ttl_set(name, status, notes=None):
+    '''
+    Update a ttl-based service check to either passing, warning, or failing
+
+    name
+        consul service to manage
+
+    status
+        passing, warning, or failing
+
+    notes
+        optional notes for operators
+        
+    '''
+
+    type = 'check'
+
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': 'Check set to %s' % (status)}
+
+    statuses = ['passing', 'warning', 'failing']
+
+    if not __salt__['consul.service_get'](name):
+        ret['comment'] = 'Check does not exist' % (name)
+
+    if status not in statuses:
+        ret['result'] = False
+        ret['comment'] = 'Check must be one of: %s' % (" ".join(s))
+        
+    else:
+        __salt__['consul.ttl_' + status[:-3] ](name, type, notes)
+    
+    return ret
     

--- a/_states/consul_check.py
+++ b/_states/consul_check.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
-Management of consul server
+Management of consul checks
 ==========================
+
+:maintainer: Aaron Bell <aarontbellgmail.com>
+:maturity: new
+:depends:    - python-consul (http://python-consul.readthedocs.org/en/latest/)
+:platform: Linux
 
 .. versionadded:: 2014.7.0
 

--- a/_states/consul_kv.py
+++ b/_states/consul_kv.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
-Management of consul server
+Management of consul key/value
 ==========================
+
+:maintainer: Aaron Bell <aarontbellgmail.com>
+:maturity: new
+:depends:    - python-consul (http://python-consul.readthedocs.org/en/latest/)
+:platform: Linux
 
 .. versionadded:: 2014.7.0
 

--- a/_states/consul_service.py
+++ b/_states/consul_service.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
-Management of consul server
+Management of consul services
 ==========================
+
+:maintainer: Aaron Bell <aarontbellgmail.com>
+:maturity: new
+:depends:    - python-consul (http://python-consul.readthedocs.org/en/latest/)
+:platform: Linux`
 
 .. versionadded:: 2014.7.0
 


### PR DESCRIPTION
This closes GH-17 GH-19.
- `ttl` functionality in execution and state mod
- `node` lists and lookups
- `datacenter` list
